### PR TITLE
Compile error in sample code for partial pattern match

### DIFF
--- a/web/_posts/2011-05-03-lesson.textile
+++ b/web/_posts/2011-05-03-lesson.textile
@@ -378,7 +378,7 @@ Because it gives you a tuple, you have to pull out the keys and values with thei
 Lucky us, we can actually use a pattern match to extract the key and value nicely.
 
 <pre>
-scala> extensions.filter(case (name, extension) => extension < 200)
+scala> extensions.filter{case (name, extension) => extension < 200}
 res0: scala.collection.immutable.Map[String,Int] = Map((steve,100), (bob,101))
 </pre>
 


### PR DESCRIPTION
I needed curly braces, not parens, to make the partial pattern match compile.
