### PR TITLE
Correcting a comma splice by using a colon instead.

### DIFF
--- a/web/_posts/2011-05-01-lesson.textile
+++ b/web/_posts/2011-05-01-lesson.textile
@@ -299,7 +299,7 @@ Note the two different styles of comments.
 
 h3. Expressions
 
-Our BasicCalculator example gave an example of how Scala is expression-oriented.  The value color was bound based on an if/else expression. Scala is highly expression-oriented, most things are expressions rather than statements.
+Our BasicCalculator example gave an example of how Scala is expression-oriented.  The value color was bound based on an if/else expression. Scala is highly expression-oriented: most things are expressions rather than statements.
 
 h3. Inheritance
 


### PR DESCRIPTION
This [comma splices](http://en.wikipedia.org/wiki/Comma_splice) could also be fixed using a semicolon or by joining the two clauses with a conjunction.
