### PR TITLE
Fix code block containing "type parameter" and dangling sentence

### DIFF
--- a/web/_posts/2011-05-01-lesson.textile
+++ b/web/_posts/2011-05-01-lesson.textile
@@ -330,9 +330,7 @@ class BMW extends Car {
 
 h2(#types). Types
 
-Earlier, you saw that we defined a function that took an <code>Int</code> which is a type of Number. Functions can also be generic and work on any type. When that occurs, you'll see a <pre>type parameter</pre> introduced with the square bracket syntax:
-
-You can introduce as many type parameters. Here's an example of a Cache of generic Keys and Values.
+Earlier, you saw that we defined a function that took an <code>Int</code> which is a type of Number. Functions can also be generic and work on any type. When that occurs, you'll see a type parameter introduced with the square bracket syntax. Here's an example of a Cache of generic Keys and Values.
 
 <pre>
 trait Cache[K, V] {


### PR DESCRIPTION
This fixes three issues:
1. "introduced with the square bracket syntax:" followed by no example of the square bracket syntax
2. "You can introduce as many type parameters."
3. "type parameter" is called out in a <pre> code block
