### PR TITLE
iss56 : trait vs abstract. mention abstract 1st. say class can ext >1 trait

### DIFF
--- a/web/basics.textile
+++ b/web/basics.textile
@@ -299,7 +299,6 @@ class ScientificCalculator(brand: String) extends Calculator(brand) {
 
 *See Also* Effective Scala points out that a <a href="http://twitter.github.com/effectivescala/#Types%20and%20Generics-Type%20aliases">Type alias</a> is better than <code>extends</code> if the subclass isn't actually different from the superclass. A Tour of Scala describes <a href="http://www.scala-lang.org/node/125">Subclassing</a>.
 
-
 h3. Overloading methods
 
 <pre>
@@ -308,6 +307,29 @@ class EvenMoreScientificCalculator(brand: String) extends ScientificCalculator(b
 }
 </pre>
 
+h3. Abstract Classes
+
+You can define an <em>abstract class</em>, a class that defines some methods but does not implement them. Instead, subclasses that extend the abstract class define these methods. You can't create an instance of an abstract class.
+
+<pre>
+scala> abstract class Shape {
+     |   def getArea():Int    // subclass should define this
+     | }
+defined class Shape
+
+scala> class Circle(r: Int) extends Shape {
+     |   def getArea():Int = { r * r * 3 }
+     | }
+defined class Circle
+
+scala> val s = new Shape
+<console>:8: error: class Shape is abstract; cannot be instantiated
+       val s = new Shape
+               ^
+
+scala> val c = new Circle(2)
+c: Circle = Circle@65c0035b
+</pre>
 
 h2(#trait). Traits
 
@@ -325,7 +347,25 @@ class BMW extends Car {
 }
 </pre>
 
+One class can extend several traits using the <code>with</code> keyword:
+
+<pre>
+class BMW extends Car with Shiny {
+  val brand = "BMW"
+  val shineRefraction = 12
+}
+</pre>
+
 *See Also* Effective Scala has opinions about <a href="http://twitter.github.com/effectivescala/#Object oriented programming-Traits">trait</a>.
+
+*When do you want a Trait instead of an Abstract Class?* If you want to define an interface-like type, you might find it difficult to choose between a trait or an abstract class. Either one lets you define a type with some behavior, asking extenders to define some other behavior. Some rules of thumb:
+
+<ul>
+<li>Favor using traits. It's handy that a class can extend several traits; a class can extend only one class.
+<li>If you need a constructor parameter, use an abstract class. Abstract class constructors can take paramaters; trait constructors can't. For example, you can't say <code>trait t(i: Int) {}</code>; the <code>i</code> parameter is illegal.
+</ul>
+
+You are not the first person to ask this question. See fuller answers at "stackoverflow:Scala traits vs abstract classes":http://stackoverflow.com/questions/1991042/scala-traits-vs-abstract-classes, "Difference between Abstract Class and Trait":http://stackoverflow.com/questions/2005681/difference-between-abstract-class-and-trait, and "Programming in Scala: To trait, or not to trait?":http://www.artima.com/pins1ed/traits.html#12.7
 
 h2(#types). Types
 


### PR DESCRIPTION
For abstract classes and extend-mult-traits, I didn't say much about 'em, but gave
syntax examples. If I were presenting this as a class, I'd probably just say
"There are abstract classes, like in that classist language you used to use.
You can extend more than one trait. I'm fast-forwarding past the syntax because
it's boring, you can look at it later."
