### PR TITLE
s/Conversions/Converters/ , s//asScala/ (watch that last one, it's a doozy)

### DIFF
--- a/web/coll2.textile
+++ b/web/coll2.textile
@@ -363,13 +363,13 @@ res56: numbers.type = Map((2,3), (4,1), (1,2))
 
 h2(#java). Life with Java
 
-You can easily move between Java and Scala collection types using a set of implicit conversions that are available in the JavaConversions package.
+You can easily move between Java and Scala collection types using conversions that are available in the <a href="http://www.scala-lang.org/api/current/index.html#scala.collection.JavaConverters$">JavaConverters package</a>. It decorates commonly-used Java collections with <code>asScala</code> methods and Scala collections with <code>asJava</code> methods.
 
 <pre>
-   import scala.collection.JavaConversions._
+   import scala.collection.JavaConverters._
    val sl = new scala.collection.mutable.ListBuffer[Int]
-   val jl : java.util.List[Int] = sl
-   val sl2 : scala.collection.mutable.Buffer[Int] = jl
+   val jl : java.util.List[Int] = sl.asJava
+   val sl2 : scala.collection.mutable.Buffer[Int] = jl.asScala
    assert(sl eq sl2)
 </pre>
 

--- a/web/concurrency.textile
+++ b/web/concurrency.textile
@@ -379,18 +379,18 @@ If you look at the implementation, you realize that it's simply synchronizing on
 
 h2.  Java ConcurrentHashMap
 
-Java comes with a nice thread-safe ConcurrentHashMap.  Thankfully, we can use JavaConversions to give us nice Scala semantics.
+Java comes with a nice thread-safe ConcurrentHashMap.  Thankfully, we can use JavaConverters to give us nice Scala semantics.
 
 In fact, we can seamlessly layer our new, thread-safe InvertedIndex as an extension of the old unsafe one.
 
 <pre>
 import java.util.concurrent.ConcurrentHashMap
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 class ConcurrentInvertedIndex(userMap: collection.mutable.ConcurrentMap[String, User])
     extends InvertedIndex(userMap) {
 
-  def this() = this(new ConcurrentHashMap[String, User])
+  def this() = this(new ConcurrentHashMap[String, User] asScala)
 }
 </pre>
 


### PR DESCRIPTION
I dunno whether Scala School used JavaConversions instead of JavaConverters on purpose, or because back then that's all there was. In case it's the latter, here's an update.
