### PR TITLE
Corrected the Pattern Matching on class members example in basics2.textile

### DIFF
--- a/web/basics2.textile
+++ b/web/basics2.textile
@@ -226,9 +226,9 @@ Let's classify them according to type.
 
 <pre>
 def calcType(calc: Calculator) = calc match {
-  case calc.brand == "hp" && calc.model == "20B" => "financial"
-  case calc.brand == "hp" && calc.model == "48G" => "scientific"
-  case calc.brand == "hp" && calc.model == "30B" => "business"
+  case calc if calc.brand == "hp" && calc.model == "20B" => "financial"
+  case calc if calc.brand == "hp" && calc.model == "48G" => "scientific"
+  case calc if calc.brand == "hp" && calc.model == "30B" => "business"
   case _ => "unknown"
 }
 </pre>


### PR DESCRIPTION
The existing code:

``` scala
def calcType(calc: Calculator) = calc match {
  case calc.brand == "hp" && calc.model == "20B" => "financial"
  case calc.brand == "hp" && calc.model == "48G" => "scientific"
  case calc.brand == "hp" && calc.model == "30B" => "business"
  case _ => "unknown"
}
```

Will produce the following errors.

```
<console>:13: error: not found: value &&
         case calc.brand == "hp" && calc.model == "20B" => "financial"
                                 ^
<console>:14: error: not found: value &&
         case calc.brand == "hp" && calc.model == "48G" => "scientific"
                                 ^
<console>:15: error: not found: value &&
         case calc.brand == "hp" && calc.model == "30B" => "business"
                                 ^
```

The cases should be converted to use guards.
