### PR TITLE
Updating pattern matching on class members

### DIFF
--- a/web/basics2.textile
+++ b/web/basics2.textile
@@ -224,16 +224,18 @@ Remember our calculator from earlier.
 
 Let's classify them according to type.
 
+Here's the painful way first.
+
 <pre>
 def calcType(calc: Calculator) = calc match {
-  case calc.brand == "hp" && calc.model == "20B" => "financial"
-  case calc.brand == "hp" && calc.model == "48G" => "scientific"
-  case calc.brand == "hp" && calc.model == "30B" => "business"
+  case _ if calc.brand == "hp" && calc.model == "20B" => "financial"
+  case _ if calc.brand == "hp" && calc.model == "48G" => "scientific"
+  case _ if calc.brand == "hp" && calc.model == "30B" => "business"
   case _ => "unknown"
 }
 </pre>
 
-Wow, that's painful. Thankfully Scala provides some nice tools specifically for this.
+Wow, that's painful.  Thankfully Scala provides some nice tools specifically for this.
 
 h2(#caseclass). Case Classes
 


### PR DESCRIPTION
In an awesome Scala school session with @jjmmcc, it came up that one of the pattern matching example isn't valid syntax.  This is what I get in 2.9.2:

```
Welcome to Scala version 2.9.2 (Java HotSpot(TM) 64-Bit Server VM, Java 1.6.0_45).
Type in expressions to have them evaluated.
Type :help for more information.

scala> case class Calculator(brand: String, model: String)
defined class Calculator

scala> :paste
// Entering paste mode (ctrl-D to finish)

def calcType(calc: Calculator) = calc match {
  case calc.brand == "hp" && calc.model == "20B" => "financial"
  case calc.brand == "hp" && calc.model == "48G" => "scientific"
  case calc.brand == "hp" && calc.model == "30B" => "business"
  case _ => "unknown"
}

// Exiting paste mode, now interpreting.

<console>:10: error: not found: value &&
         case calc.brand == "hp" && calc.model == "20B" => "financial"
                                 ^
<console>:11: error: not found: value &&
         case calc.brand == "hp" && calc.model == "48G" => "scientific"
                                 ^
<console>:12: error: not found: value &&
         case calc.brand == "hp" && calc.model == "30B" => "business"
                                 ^
scala> calc match {
     | case calc.brand == "hp" => "hhhhhhp"
     | case _ => "unknown"
     | }
<console>:8: error: not found: value calc
              calc match {
              ^
<console>:9: error: value == is not a case class constructor, nor does it have an unapply/unapplySeq method
              case calc.brand == "hp" => "hhhhhhp"
                              ^
```

So I updated the example.
