### PR TITLE
Updated for latest Jekyll

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 all:
-	jekyll web web.out
+	jekyll build -s web -d web.out
 
 serve:
-	jekyll --serve --auto web web.out
+	jekyll serve --watch -s web -d web.out
 
 publish: all
 	./publish.sh web.out


### PR DESCRIPTION
Jekyll now uses subcommands. I have updated the Makefile to build and serve correctly. We should either ensure everything works on the latest version of packages or define package versions in a Gemfile.
