### PR TITLE
Fix compilation error in SearchBird example code

### DIFF
--- a/web/searchbird.textile
+++ b/web/searchbird.textile
@@ -291,7 +291,7 @@ def put(key: String, value: String) = {
 
   // serialize updaters
   synchronized {
-    value.split(" ").toSet foreach { token =>
+    value.split(" ").toSet[String] foreach { token =>
       val current = reverse.getOrElse(token, Set())
       reverse(token) = current + key
     }


### PR DESCRIPTION
Following code in SearchBird example will produce compilation error:

```scala
value.split(" ").toSet foreach { token => ... }

error: missing parameter type for expanded function...
```

It should be:

```scala
value.split(" ").toSet[String] foreach { token => ... }
// or
value.split(" ").toSet foreach { token: String => ...}
```

Detailed discussion about the type inference can be found here:
http://stackoverflow.com/questions/5544536/type-inference-on-set-failing