### PR TITLE
Make Finagle url actually a link

### DIFF
--- a/web/advanced-types.textile
+++ b/web/advanced-types.textile
@@ -321,7 +321,7 @@ res10: String = ""
 
 h2(#finagle). Case study: Finagle
 
-See: https://github.com/twitter/finagle
+See: "https://github.com/twitter/finagle":https://github.com/twitter/finagle
 
 <pre>
 trait Service[-Req, +Rep] extends (Req => Future[Rep])


### PR DESCRIPTION
Plain URLs are autolinked with Github Flavored Markdown, but not Textile. At least, not the flavor that's used to generate the page at http://twitter.github.io/scala_school/advanced-types.html.
