### PR TITLE
Change jekyll build in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	jekyll web web.out
+	jekyll build --source web --destination web.out
 
 serve:
 	jekyll serve --watch -s web -d web.out


### PR DESCRIPTION
jekyll build is failed on Fedora 19, jekyll 1.4.3. Changed command parameters of jekyll and build is passed.