### PR TITLE
Corrected map combinator example

### DIFF
--- a/web/collections.textile
+++ b/web/collections.textile
@@ -185,14 +185,14 @@ scala> numbers.map((i: Int) => i * 2)
 res0: List[Int] = List(2, 4, 6, 8)
 </pre>
 
-or pass in a partially evaluated function
+or pass in a function
 
 <pre>
 
 scala> def timesTwo(i: Int): Int = i * 2
 timesTwo: (i: Int)Int
 
-scala> numbers.map(timesTwo _)
+scala> numbers.map(timesTwo)
 res0: List[Int] = List(2, 4, 6, 8)
 </pre>
 

--- a/web/collections.textile
+++ b/web/collections.textile
@@ -185,7 +185,7 @@ scala> numbers.map((i: Int) => i * 2)
 res0: List[Int] = List(2, 4, 6, 8)
 </pre>
 
-or pass in a function
+or pass in a function (the Scala compiler automatically converts our method to a function)
 
 <pre>
 


### PR DESCRIPTION
The map combinator example performs eta-expansion on the timesTwo method (unnecessarily, Scala does it automatically in this case), however the description above says that it's partial evaluation. Maybe it'd be better to remove the part about partial evaluation and just pass timesTwo without doing the eta-expansion? Alternatively  "partially evaluated function" could be replaced with "eta-expanded method", but maybe that would make it look too complicated.