### PR TITLE
Fixing type error in map sample code

### DIFF
--- a/web/collections.textile
+++ b/web/collections.textile
@@ -130,14 +130,14 @@ Let's look at an example of how Option is used:
 <code>Map.get</code> uses <code>Option</code> for its return type. Option tells you that the method might not return what you're asking for.
 
 <pre>
-scala> val numbers = Map(1 -> "one", 2 -> "two")
-numbers: scala.collection.immutable.Map[Int,String] = Map((1,one), (2,two))
+scala> val numbers = Map("one" -> 1, "two" -> 2)
+numbers: scala.collection.immutable.Map[java.lang.String,Int] = Map(one -> 1, two -> 2)
 
-scala> numbers.get(2)
-res0: Option[java.lang.String] = Some(two)
+scala> numbers.get("two")
+res0: Option[Int] = Some(2)
 
-scala> numbers.get(3)
-res1: Option[java.lang.String] = None
+scala> numbers.get("three")
+res1: Option[Int] = None
 </pre>
 
 Now our data appears trapped in this <code>Option</code>. How do we work with it?

--- a/web/ko/collections.textile
+++ b/web/ko/collections.textile
@@ -129,14 +129,14 @@ trait Option[T] {
 <code>Map.get</code>은 <code>Option</code>를 반환한다. 옵션을 반환한다는 것은 찾는 값이 없을 수도 있다는 의미이다.
 
 <pre>
-scala> val numbers = Map(1 -> "one", 2 -> "two")
-numbers: scala.collection.immutable.Map[Int,String] = Map((1,one), (2,two))
+scala> val numbers = Map("one" -> 1, "two" -> 2)
+numbers: scala.collection.immutable.Map[java.lang.String,Int] = Map(one -> 1, two -> 2)
 
-scala> numbers.get(2)
-res0: Option[java.lang.String] = Some(two)
+scala> numbers.get("two")
+res0: Option[Int] = Some(2)
 
-scala> numbers.get(3)
-res1: Option[java.lang.String] = None
+scala> numbers.get("three")
+res1: Option[Int] = None
 </pre>
 
 이제 데이터가 <code>Option</code>에 들어가 있을 것이다. 그럼 그 옵션을 가지고는 무얼 할 수 있을까?

--- a/web/ru/collections.textile
+++ b/web/ru/collections.textile
@@ -129,14 +129,14 @@ trait Option[T] {
 <code>Map.get</code> использует <code>Option</code> для возврата собственных значений. Опция говорит вам, что метод может не вернуть того значения, которое мы запросили.
 
 <pre>
-scala> val numbers = Map(1 -> "one", 2 -> "two")
-numbers: scala.collection.immutable.Map[Int,String] = Map((1,one), (2,two))
+scala> val numbers = Map("one" -> 1, "two" -> 2)
+numbers: scala.collection.immutable.Map[java.lang.String,Int] = Map(one -> 1, two -> 2)
 
-scala> numbers.get(2)
-res0: Option[java.lang.String] = Some(two)
+scala> numbers.get("two")
+res0: Option[Int] = Some(2)
 
-scala> numbers.get(3)
-res1: Option[java.lang.String] = None
+scala> numbers.get("three")
+res1: Option[Int] = None
 </pre>
 
 Теперь наши данные отлавливаются с помощью <code>Option</code>. Как мы можем это использовать?

--- a/web/zh_cn/collections.textile
+++ b/web/zh_cn/collections.textile
@@ -130,14 +130,14 @@ Option本身是泛型的，并且有两个子类： <code>Some[T]</code> 或 <co
 <code>Map.get</code> 使用 <code>Option</code> 作为其返回值，表示这个方法也许不会返回你请求的值。
 
 <pre>
-scala> val numbers = Map(1 -> "one", 2 -> "two")
-numbers: scala.collection.immutable.Map[Int,String] = Map((1,one), (2,two))
+scala> val numbers = Map("one" -> 1, "two" -> 2)
+numbers: scala.collection.immutable.Map[java.lang.String,Int] = Map(one -> 1, two -> 2)
 
-scala> numbers.get(2)
-res0: Option[java.lang.String] = Some(two)
+scala> numbers.get("two")
+res0: Option[Int] = Some(2)
 
-scala> numbers.get(3)
-res1: Option[java.lang.String] = None
+scala> numbers.get("three")
+res1: Option[Int] = None
 </pre>
 
 现在我们的数据似乎陷在<code>Option</code>中了，我们怎样获取这个数据呢？


### PR DESCRIPTION
The samples assume operations over Int values, so instead of changing the samples I just change the sample data to using Map[Int, String] to be Map[String, Int] and everything works good now (tested on Scala 2.9.2 console)