### PR TITLE
Re-define numbers in the Functional Combinators section

### DIFF
--- a/web/collections.textile
+++ b/web/collections.textile
@@ -181,6 +181,9 @@ h2(#map). map
 Evaluates a function over each element in the list, returning a list with the same number of elements.
 
 <pre>
+scala> val numbers = List(1, 2, 3, 4)
+numbers: List[Int] = List(1, 2, 3, 4)
+
 scala> numbers.map((i: Int) => i * 2)
 res0: List[Int] = List(2, 4, 6, 8)
 </pre>


### PR DESCRIPTION
The previous statement defines 'numbers' as being of type String, Int -- but the Functional Combinators: Map example is using 'numbers' as type List.