### PR TITLE
Compilation might fail when using develop branch

### DIFF
--- a/web/finagle.textile
+++ b/web/finagle.textile
@@ -26,6 +26,7 @@ If you have the Finagle source code in a directory named <code>finagle</code>, y
 
 <pre>
 $ cd finagle
+$ git checkout master
 $ ./sbt "project finagle-http" console
  ...build output...
 scala>

--- a/web/ko/finagle.textile
+++ b/web/ko/finagle.textile
@@ -27,6 +27,7 @@ h2(#repl). 피네이글 환경의 REPL
 
 <pre>
 $ cd finagle
+$ git checkout master
 $ ./sbt "project finagle-http" console
  ...build output...
 scala>

--- a/web/zh_cn/finagle.textile
+++ b/web/zh_cn/finagle.textile
@@ -28,6 +28,7 @@ h2(#repl). Finagle-Friendly REPL
 
 <pre>
 $ cd finagle
+$ git checkout master
 $ ./sbt "project finagle-http" console
  ...build output...
 scala>


### PR DESCRIPTION
When I tried to start the sbt console as instructed in the tutorial, I got an unresolved dependency error. This probably happens because the default(develop) branch expects a version of twitter-util which is under development. We can avoid this error by using the master branch.

I've updated instructions to checkout master branch to ensure compilation succeeds.