### PR TITLE
remove additional parenthesis

### DIFF
--- a/web/ko/sbt.textile
+++ b/web/ko/sbt.textile
@@ -179,7 +179,7 @@ scala> val parser = new SimpleParser
 parser: com.twitter.sample.SimpleParser = com.twitter.sample.SimpleParser@71060c3e
 
 scala> parser.parse(tweet)                    
-res0: Option[com.twitter.sample.SimpleParsed] = Some(SimpleParsed(1,"foo"}))
+res0: Option[com.twitter.sample.SimpleParsed] = Some(SimpleParsed(1,"foo"))
 
 scala> 
 </pre>

--- a/web/ru/sbt.textile
+++ b/web/ru/sbt.textile
@@ -183,7 +183,7 @@ scala> val parser = new SimpleParser
 parser: com.twitter.sample.SimpleParser = com.twitter.sample.SimpleParser@71060c3e
 
 scala> parser.parse(tweet)                    
-res0: Option[com.twitter.sample.SimpleParsed] = Some(SimpleParsed(1,"foo"}))
+res0: Option[com.twitter.sample.SimpleParsed] = Some(SimpleParsed(1,"foo"))
 
 scala> 
 </pre>

--- a/web/sbt.textile
+++ b/web/sbt.textile
@@ -183,7 +183,7 @@ scala> val parser = new SimpleParser
 parser: com.twitter.sample.SimpleParser = com.twitter.sample.SimpleParser@71060c3e
 
 scala> parser.parse(tweet)                    
-res0: Option[com.twitter.sample.SimpleParsed] = Some(SimpleParsed(1,"foo"}))
+res0: Option[com.twitter.sample.SimpleParsed] = Some(SimpleParsed(1,"foo"))
 
 scala> 
 </pre>

--- a/web/zh_cn/sbt.textile
+++ b/web/zh_cn/sbt.textile
@@ -182,7 +182,7 @@ scala> val parser = new SimpleParser
 parser: com.twitter.sample.SimpleParser = com.twitter.sample.SimpleParser@71060c3e
 
 scala> parser.parse(tweet)                    
-res0: Option[com.twitter.sample.SimpleParsed] = Some(SimpleParsed(1,"foo"}))
+res0: Option[com.twitter.sample.SimpleParsed] = Some(SimpleParsed(1,"foo"))
 
 scala> 
 </pre>


### PR DESCRIPTION
While going through the docs, came across what seems like a typo.

`Some(SimpleParsed(1,"foo"}))`

Thanks for the tutorial!