### PR TITLE
Adds jekyll-textile-converter gem dependency. Fixes #176

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ should do. Now, build the site with `make`. This will create a copy of the lesso
 For development, you'll also need to install [RedCloth](http://redcloth.org/).
 
 	$ gem install RedCloth
+    $ gem install jekyll-textile-converter
 
 Then `make serve` will launch `jekyll` in serving mode: a web server will be launched on port 4000, and changing files will automatically rebuild the site.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ should do. Now, build the site with `make`. This will create a copy of the lesso
 For development, you'll also need to install [RedCloth](http://redcloth.org/).
 
 	$ gem install RedCloth
-    $ gem install jekyll-textile-converter
+	$ gem install jekyll-textile-converter
 
 Then `make serve` will launch `jekyll` in serving mode: a web server will be launched on port 4000, and changing files will automatically rebuild the site.
 

--- a/web/_config.yml
+++ b/web/_config.yml
@@ -1,3 +1,5 @@
+gems:
+- jekyll-textile-converter
 permalink: none
 lessons:
   - 


### PR DESCRIPTION
Looks like RedCloth integration was moved to a side plugin (https://github.com/jekyll/jekyll/issues/3316).