### PR TITLE
Fix css path for local viewing

### DIFF
--- a/web/_layouts/default.html
+++ b/web/_layouts/default.html
@@ -12,7 +12,7 @@
     <![endif]-->
 
     <!-- Le styles -->
-    <link rel="stylesheet" href="/scala_school/bootstrap-1.1.0.min.css">
+    <link rel="stylesheet" href="bootstrap-1.1.0.min.css">
 
     <style>
     h2 { padding-top: 0px; }


### PR DESCRIPTION
The CSS path is only setup to work on the github.io pages. This change makes it work for both the github.io pages and local viewing via the built-in jekyll server.

I tested it locally on Chrome 49.0.2623.87 on OSX:
- Navigating to localhost:4000 after starting `make serve` works
- Modifying the CSS path on https://twitter.github.io/scala_school/ in the Chrome "Developer Tools" also worked