### PR TITLE
scala.actor.Future -> scala.concurrent.Future

### DIFF
--- a/web/finagle.textile
+++ b/web/finagle.textile
@@ -680,6 +680,6 @@ Finagle automatically juggles threads to keep your service running smoothly. How
 * If your code calls a blocking operation (<code>apply</code> or <code>get</code>), use a <a href="https://github.com/twitter/finagle#Using%20Future%20Pools">Future Pool</a> to wrap the blocking code. This runs the blocking operation in its own thread pool, giving you a Future for the completion (or failure) of that operation which you can compose with other Futures.
 * If your code uses sequential composition of Futures, don't worry that it's "blocking" on those Futures.
 
-fn1. Careful, there are other "Future" classes out there. Don't confuse <code>com.twitter.util.Future</code> with <code>scala.actor.Future</code> or <code>java.util.concurrent.Future</code>!
+fn1. Careful, there are other "Future" classes out there. Don't confuse <code>com.twitter.util.Future</code> with <code>scala.concurrent.Future</code> or <code>java.util.concurrent.Future</code>!
 
 fn2. If you study type systems and/or category theory, you'll be glad to learn that <code>flatMap</code> is equivalent to a monadic bind.

--- a/web/ko/finagle.textile
+++ b/web/ko/finagle.textile
@@ -690,6 +690,6 @@ h2(#DontBlock). 블록하지 말자(제대로 하는게 아니라면)
 
 * Future의 순차 합성을 사용한다면 Future중이 블록되는게 있는지 우려할 필요가 없다.
 
-fn1. 경고. 다른 "Future" 클래스도 존재한다. <code>com.twitter.util.Future</code>을 <code>scala.actor.Future</code>나 <code>java.util.concurrent.Future</code>와 혼동하지 말라!
+fn1. 경고. 다른 "Future" 클래스도 존재한다. <code>com.twitter.util.Future</code>을 <code>scala.concurrent.Future</code>나 <code>java.util.concurrent.Future</code>와 혼동하지 말라!
 
 fn2. <code>flatMap</code>이 모나드의 바인드(bind) 연산이다. 타입 시스템이나 카테고리 이론을 공부하는 독자라면 이해하리라 본다.

--- a/web/zh_cn/finagle.textile
+++ b/web/zh_cn/finagle.textile
@@ -690,6 +690,6 @@ Finagle 自动操纵线程来保证服务顺利运行。但是，如果你的服
 
 * 如果你的代码中使用Future的顺序组合，不用担心它会“阻塞”组合中的Future。
 
-fn1. 小心，还有其它“Future”类。不要将<code>com.twitter.util.Future</code> 和<code>scala.actor.Future</code> 或 <code>java.util.concurrent.Future</code>混淆起来！
+fn1. 小心，还有其它“Future”类。不要将<code>com.twitter.util.Future</code> 和<code>scala.concurrent.Future</code> 或 <code>java.util.concurrent.Future</code>混淆起来！
 
 fn2. 如果你学习类型系统和/或分类理论，你会高兴地发现<code>flatMap</code>相当于一元绑定。


### PR DESCRIPTION
The Finagle section of the docs mentions `scala.actor.Future` as a class to not mix up with Twitter Futures. This was a typo, as the class was named [`scala.actors.Future`](http://www.scala-lang.org/api/2.8.1/scala/actors/Future.html). More importantly, it's been [deprecated](http://docs.scala-lang.org/overviews/core/actors-migration-guide.html) since Scala 2.11 was released and has been replaced with `scala.concurrent.Future`.
