### PR TITLE
missing sample of using capitalizeAll fuction

### DIFF
--- a/web/ru/basics.textile
+++ b/web/ru/basics.textile
@@ -239,6 +239,9 @@ def capitalizeAll(args: String*) = {
     arg.capitalize
   }
 }
+
+scala> capitalizeAll("rarity", "applejack")
+res2: Seq[String] = ArrayBuffer(Rarity, Applejack)
 </pre>
 
 h2(#class). Классы


### PR DESCRIPTION
Original (en) version has sample of using capitalizeAll function (see Variable length arguments)