### PR TITLE
Fix incorrect link on the Finagle's page 

### DIFF
--- a/web/finagle.textile
+++ b/web/finagle.textile
@@ -8,7 +8,7 @@ layout: post
 "Finagle":https://github.com/twitter/finagle is Twitter's RPC system. "This":https://blog.twitter.com/2011/finagle-a-protocol-agnostic-rpc-system blog post explains its motivations and core design tenets, the "finagle README":https://github.com/twitter/finagle/blob/master/README.md contains more detailed documentation. Finagle aims to make it easy to build robust clients and servers.
 
 * "REPL":#repl
-* "Futures":#Future: "Sequential composition":#futsequential, "Concurrent composition":#futconcurrent, "Composition Example: Cached Rate Limit":#combined_combinator_example_cache, "Composition Example: Thumbnail Fetcher":#combined_combinator_thumbnail
+* "Futures":#Future: "Sequential composition":#futsequential, "Concurrent composition":#futconcurrent, "Composition Example: Cached Rate Limit":#combined_combinator_example_cache, "Composition Example: Web Crawlers":#combined_combinator_example_thumbnail
 * "Service":#Service
 * "Client Example":#client
 * "Server Example":#server
@@ -326,7 +326,7 @@ This hypothetical example combines sequential and concurrent composition. Note t
 
 <a name="combined_combinator_example_thumbnail">&nbsp;</a>
 
-h3. Composition Examples: Web Crawlers
+h3. Composition Example: Web Crawlers
 
 You've seen how to use combinators with Futures, but might appreciate  more examples. Suppose you have a simple model of the internet. It has HTML pages and images. Pages can link to images and link to other pages. You can fetch a page or an image, but the API is asynchronous. This fake API calls these "fetchable" things Resources:
 

--- a/web/ko/finagle.textile
+++ b/web/ko/finagle.textile
@@ -9,7 +9,7 @@ layout: post
 "이 블로그 글":https://blog.twitter.com/2011/finagle-a-protocol-agnostic-rpc-system 은 만들게 된 동기와 설계 원칙을, "피네이글 README":https://github.com/twitter/finagle/blob/master/README.md 에는 더 자세한 설명이 있다. 피네이글은 튼튼한 클라이언트와 서버를 쉽게 만들려는 목적으로 쓰여졌다.
 
 * "REPL":#repl
-* "Future":#Future: "순차 합성":#futsequential, "동시 합성":#futconcurrent, "합성 예제: 캐시된 비율 제한":#combined_combinator_example_cache, "합성 예제: 썸네일 페치 장치":#combined_combinator_thumbnail
+* "Future":#Future: "순차 합성":#futsequential, "동시 합성":#futconcurrent, "합성 예제: 캐시된 비율 제한":#combined_combinator_example_cache, "합성 예제: 썸네일 페치 장치":#combined_combinator_example_thumbnail
 * "Service":#Service
 * "클라이언트 예제":#client
 * "서버 예제":#server


### PR DESCRIPTION
Fixes incorrect link on the Finagle's page (English and Korean...Chinese is ok and Russian does not have it). Also updates the title to which the link is associated to be consistent with the title in the linked section ("Composition Example: Thumbnail Fetcher" -> "Composition Example: Web Crawlers")
#191