### PR TITLE
Add import scala.language.implicitConversions

### DIFF
--- a/web/advanced-types.textile
+++ b/web/advanced-types.textile
@@ -23,6 +23,8 @@ Sometimes you don't need to specify that one type is equal/sub/super another, ju
 *Implicit* functions allow automatic conversion. More precisely, they allow on-demand function application when this can help satisfy type inference. e.g.:
 
 <pre>
+import scala.language.implicitConversions
+
 scala> implicit def strToInt(x: String) = x.toInt
 strToInt: (x: String)Int
 


### PR DESCRIPTION
"import scala.language.implicitConversions" with the current version of Scala. Otherwise I receive an error message when I run the function definition :

"advanced_type.scala:11: warning: implicit conversion method strToInt shoulnabled
by making the implicit value scala.language.implicitConversions visible.
This can be achieved by adding the import clause 'import scala.language.imConversions'
or by setting the compiler option -language:implicitConversions.
See the Scaladoc for value scala.language.implicitConversions for a discus
why the feature should be explicitly enabled."