### PR TITLE
Fix path to stylesheets

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,9 @@
     <![endif]-->
 
     <!-- Le styles -->
-    <link rel="stylesheet" href="/bootstrap-1.1.0.min.css">
-    <link rel="stylesheet" href="/style.css">
-    <link rel="stylesheet" href="/small-screens.css">
+    <link rel="stylesheet" href="bootstrap-1.1.0.min.css">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="small-screens.css">
 
     <style>
     h2 { padding-top: 0px; }


### PR DESCRIPTION
Hello!

The page is broken because the path to the style sheets is absolutely to the GitHub domain. This Pull Request fixes it. The change can be viewed at https://orkohunter.github.io/scala_school/