### PR TITLE
Fixed the link to effectivescala

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -31,7 +31,7 @@ title: Scala School
           <h2>Also</h2>
           <p>You can learn more elsewhere:
           <ul>
-          <li><strong><a href="https://twitter.github.com/effectivescala/">Effective Scala</a></strong> Twitter's "best practices" for Scala. Useful for understanding idioms in Twitter's code.</li>
+          <li><strong><a href="https://twitter.github.io/effectivescala/">Effective Scala</a></strong> Twitter's "best practices" for Scala. Useful for understanding idioms in Twitter's code.</li>
           <li><strong><a href="https://docs.scala-lang.org">scala-lang.org Documentation</a></strong> Links to tutorials, manuals, API reference, books, ...</li>
           <li><strong><a href="https://www.scala-lang.org/api/">Scala API Documentation</a></strong></li>
           </ul>


### PR DESCRIPTION
GitHub deprecated subdomains of `github.com`

> If you're the owner of this site, please update your links to use twitter.github.io instead. Subdomains of github.com are deprecated for GitHub Pages. They will not redirect to github.io after April 15, 2021.